### PR TITLE
Re-hash proftpd::options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,12 +15,14 @@ class proftpd::config {
     else { $real_defaults = $::proftpd::default_options }
 
     # check if defaults should be included
+    # re-hash due to hiera 1.x known limitation
+    $hash_options = hiera_hash('proftpd::options',$::proftpd::options)
     if ( $::proftpd::default_config == true ) {
-      $real_options = deep_merge($real_defaults, $::proftpd::options)
+      $real_options = deep_merge($real_defaults, $hash_options)
     }
     # do not include defaults
-    else { $real_options = $::proftpd::options }
-
+    else { $real_options = $hash_options }
+    
     # required variables
     $base_dir     = $::proftpd::base_dir
     $load_modules = $::proftpd::load_modules

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,7 +22,7 @@ class proftpd::config {
     }
     # do not include defaults
     else { $real_options = $hash_options }
-    
+
     # required variables
     $base_dir     = $::proftpd::base_dir
     $load_modules = $::proftpd::load_modules


### PR DESCRIPTION
proftpd::options needs to be re-hashed in config.pp due to known hiera limitation