### PR TITLE
Use native ruby split in erb

### DIFF
--- a/templates/proftpd.conf.erb
+++ b/templates/proftpd.conf.erb
@@ -49,7 +49,7 @@ Include <%= @base_dir %>/modules.conf
 <%                   # check if this is the last value for this tag -%>
 <%                   if aiii[-1] == kiiii -%>
 <%                     # split opening tag to get closing tag -%>
-<%                     close_tag = scope.function_split([kiii, ' ']) -%>
+<%                     close_tag = kiii.split(' ') -%>
       </<%=            close_tag[0] %>>
 <%                   end -%>
 <%                 end -%>
@@ -68,7 +68,7 @@ Include <%= @base_dir %>/modules.conf
 <%               # check if this is the last value for this tag -%>
 <%               if aii[-1] == kiii -%>
 <%                 # split opening tag to get closing tag -%>
-<%                 close_tag = scope.function_split([kii, ' ']) -%>
+<%                 close_tag = kii.split(' ') -%>
     </<%=          close_tag[0] %>>
 <%               end -%>
 <%             end -%>
@@ -87,7 +87,7 @@ Include <%= @base_dir %>/modules.conf
 <%           # check if this is the last value for this tag -%>
 <%           if ai[-1] == kii -%>
 <%             # split opening tag to get closing tag -%>
-<%             close_tag = scope.function_split([ki, ' ']) -%>
+<%             close_tag = ki.split(' ') -%>
   </<%=      close_tag[0] %>>
 <%           end -%>
 <%         end -%>
@@ -106,7 +106,7 @@ Include <%= @base_dir %>/modules.conf
 <%       # check if this is the last value for this tag -%>
 <%       if options_array[-1] == ki and k != 'ROOT' -%>
 <%         # split opening tag to get closing tag -%>
-<%         close_tag = scope.function_split([k, ' ']) -%>
+<%         close_tag = k.split(' ') -%>
 </<%=      close_tag[0] %>>
 <%       end -%>
 <%     end -%>


### PR DESCRIPTION
The template in this module is manipulating data originally passed as a
string. The string data needs to be converted to an array. To achieve
this, the puppet parser function `split` was used. This did work but
will no longer be functional as the manner of calling these functions
has changed in Puppet 4. The Puppet parser split does not much more than
just expose the native ruby split to the Puppet DSL. In the ERB we have
full access to Ruby and do not need to invoke this internal parser
function.

This commit changes the method of splitting strings to use the native
ruby function. This change was tested to show that the original effect
of the ERB was still being achieved. This template is also now Puppet 4
ready, though once the module drops Puppet 3, EPP should be preferred
over ERB.