### PR TITLE
Fix validation failing because it can't load shared libraries

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -72,7 +72,7 @@ class proftpd::config {
         ensure       => file,
         mode         => $::proftpd::config_mode,
         content      => template($::proftpd::config_template),
-        validate_cmd => "${::proftpd::prefix_bin}/proftpd -t -c %",
+        validate_cmd => "LD_LIBRARY_PATH=/usr/libexec/proftpd ${::proftpd::prefix_bin}/proftpd -t -c %",
         owner        => $::proftpd::config_user,
         group        => $::proftpd::config_group;
     }


### PR DESCRIPTION
This fixes issue where validation fails because shared libraries can't be found.
Only concern is this is hardcoding the shared library path which could be different on another platform.
If you want to change this it would have to be added as path in params and then included in the config.pp  to reference that on per osfamily.
I think it should work across the board but just wanted to point it out.