### PR TITLE
Remove deprecated concat::fragment parameter

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -3,7 +3,6 @@
 define proftpd::module ($enable = true, $order = '10') {
   # Load module .c file from modules.conf.
   concat::fragment { "proftp_module_${name}":
-    ensure  => present,
     target  => "${::proftpd::base_dir}/modules.conf",
     content => "LoadModule mod_${name}.c \n",
     order   => $order,

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/fraenki/puppet-proftpd/issues",
   "description": "Puppet module to manage ProFTPD on FreeBSD and Linux with very flexible, hiera-friendly configuration",
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0 <3.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0 <5.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 <5.0.0" }
   ],
   "requirements": [


### PR DESCRIPTION
The "ensure" parameter for concat::fragment has been deprecated for some
time, and was removed entirely in version 4.